### PR TITLE
Serial unit test, Getter functions for unspenttxout, and comparator function utils.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ Merkle_OBJ = src/merkle.o
 Network_OBJ = src/network.o src/socket.o
 FullNode_OBJ = src/fullNode.o
 Serialize_OBJ = src/serialize.o
+Comparator_OBJ = src/comparator.o
 
 #Compiles the main capcoin program and its prerequisutes
-Capcoin_OBJ = src/capcoin.o $(Transaction_OBJ) $(Block_OBJ) $(Serialize_OBJ) $(Network_OBJ) $(FullNode_OBJ)
+Capcoin_OBJ = src/capcoin.o $(Transaction_OBJ) $(Block_OBJ) $(Serialize_OBJ) $(Network_OBJ) $(FullNode_OBJ) $(Comparator_OBJ)
 
 #Where to store all drivers
 EXEC_DIR = ./bin/

--- a/lib/comparator.h
+++ b/lib/comparator.h
@@ -1,0 +1,19 @@
+#include "txin.h"
+#include "txout.h"
+#include "utxout.h"
+#include "transaction.h"
+#include "block.h"
+
+bool compareUTxOut(UnspentTxOut left, UnspentTxOut right);
+
+bool compareTxIn(TxIn left, TxIn right);
+
+bool compareTxOut(TxOut left, TxOut right);
+
+bool compareTxInList(std::vector<TxIn> left, std::vector<TxIn> right);
+
+bool compareTxOutList(std::vector<TxOut> left, std::vector<TxOut> right);
+
+bool compareTransaction(Transaction left, Transaction right);
+
+bool compareBlock(Block left, Block right);

--- a/src/comparator.cpp
+++ b/src/comparator.cpp
@@ -1,0 +1,76 @@
+#include "comparator.h"
+#include <iostream>
+
+bool compareUTxOut(UnspentTxOut left, UnspentTxOut right) {
+    bool all_pass = true;
+    all_pass = all_pass && (left.GetId() == right.GetId());
+    all_pass = all_pass && (left.GetAddress() == right.GetAddress());
+    all_pass = all_pass && (left.GetIndex() == right.GetIndex());
+    all_pass = all_pass && (left.GetAmount() == right.GetAmount());
+    return all_pass;
+
+}
+
+bool compareTransaction(Transaction left, Transaction right) {
+    bool all_pass = true;
+    all_pass = all_pass && (compareTxInList(left.GetTxIns(),right.GetTxIns()));
+
+    all_pass = all_pass && (compareTxOutList(left.GetTxOuts(), right.GetTxOuts()));
+    return all_pass;
+}
+
+bool compareTxInList(std::vector<TxIn> left, std::vector<TxIn> right) {
+    if(left.size() != right.size())
+        return false;
+    for(size_t i = 0; i < left.size(); i++) {
+        if(!compareTxIn(left[i],right[i]))
+          return false;  
+    }
+    return true;
+}
+
+bool compareTxOutList(std::vector<TxOut> left, std::vector<TxOut> right) {
+    if(left.size() != right.size())
+        return false;
+    for(size_t i = 0; i < left.size(); i++) {
+        if(!compareTxOut(left[i],right[i]))
+            return false;
+    }
+    return true;
+}
+
+bool compareTxIn(TxIn left, TxIn right) {
+    bool all_pass = true;
+    all_pass = all_pass && (left.GetVal() == right.GetVal());
+    all_pass = all_pass && (left.GetId() == right.GetId());
+    all_pass = all_pass && (left.GetSignature() == right.GetSignature());
+    all_pass = all_pass && (left.GetIndex() == right.GetIndex());
+    return all_pass;
+}
+
+bool compareTxOut(TxOut left, TxOut right) {
+    bool all_pass = true;
+    all_pass = all_pass && (left.GetVal() == right.GetVal());
+    all_pass = all_pass && (left.GetAddress() == right.GetAddress());
+    all_pass = all_pass && (left.GetAmount() == right.GetAmount());
+    return all_pass;
+}
+
+bool compareBlock(Block left, Block right) {
+    bool all_pass = true;
+    all_pass = all_pass && (left.GetIndex() == right.GetIndex());
+    all_pass = all_pass && (left.GetTimestamp() == right.GetTimestamp());
+    all_pass = all_pass && (left.GetDifficulty() == right.GetDifficulty());
+    all_pass = all_pass && (left.GetNonce() == right.GetNonce());
+    all_pass = all_pass && (left.GetHash() == right.GetHash());
+    all_pass = all_pass && (left.GetPreviousHash() == right.GetPreviousHash());
+    std::vector<Transaction> l_tlist = left.GetData();
+    std::vector<Transaction> r_tlist = right.GetData();
+    if(l_tlist.size() != r_tlist.size())
+        return false;
+    for(size_t i = 0; i < l_tlist.size(); i++) {
+        if(!compareTransaction(l_tlist[i], r_tlist[i]))
+            return false;
+    }
+    return all_pass;
+}

--- a/src/utxout.cpp
+++ b/src/utxout.cpp
@@ -1,4 +1,19 @@
 #include "utxout.h"
 
-UnspentTxOut::UnspentTxOut(std::string txOutId, std::string address, size_t txOutIndex, size_t amount):
-                txOutId_{txOutId}, address_{address}, txOutIndex_{txOutIndex}, amount_{amount}{}
+UnspentTxOut::UnspentTxOut(std::string txOutId, std::string address, size_t txOutIndex, size_t amount): txOutId_{txOutId}, address_{address}, txOutIndex_{txOutIndex}, amount_{amount}{}
+
+std::string UnspentTxOut::GetId() {
+    return txOutId_;
+}
+
+std::string UnspentTxOut::GetAddress() {
+    return address_;
+}
+
+size_t UnspentTxOut::GetIndex() {
+    return txOutIndex_;
+}
+
+size_t UnspentTxOut::GetAmount() {
+    return amount_;
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -19,6 +19,9 @@ GTEST_DIR = googletest/googletest
 # Where to find user code.
 USER_DIR = .
 
+# Tells compiler where to find header files
+INCLUDES = -I ../lib/ -I $(TEST_UTILS)
+
 # Project src directory
 CAP_SRC = ../src
 
@@ -35,7 +38,7 @@ CXXFLAGS += -g -Wall -Wextra -pthread
 
 # All tests produced by this Makefile.  Remember to add new tests you
 # created to the list.
-TESTS = sample_unittest transaction_unittest
+TESTS = sample_unittest transaction_unittest serialize_unittest
 
 # All Google Test headers.  Usually you shouldn't change this
 # definition.
@@ -97,13 +100,36 @@ sample_unittest : sample.o sample_unittest.o gtest_main.a
 #
 #
 ####################################################################
-TRANSACTION_OBJS = $(CAP_SRC)/transaction.o\
-				   $(CAP_SRC)/txin.o $(CAP_SRC)/txout.o $(CAP_SRC)/utxout.o\
-				   $(TEST_UTILS)/test_transaction_utils.o\
 
+# Transaction Unit Test
+TRANSACTION_OBJS = $(CAP_SRC)/transaction.o\
+				   $(CAP_SRC)/txin.o $(CAP_SRC)/txout.o\
+				   $(CAP_SRC)/utxout.o
+				   
+test_transaction_utils.o : $(TEST_UTILS)/test_transaction_utils.cpp\
+							$(TEST_UTILS)/test_transaction_utils.h
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(TEST_UTILS)/test_transaction_utils.cpp
+   	
 transaction_unittest.o : $(USER_DIR)/transaction_unittest.cc\
 						$(GTEST_HEADERS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(USER_DIR)/transaction_unittest.cc
 
-transaction_unittest: transaction_unittest.o gtest_main.a
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -lpthread $(TRANSACTION_OBJS) $^ -o $(USER_DIR)/bin/$@
+transaction_unittest: $(TRANSACTION_OBJS) test_transaction_utils.o transaction_unittest.o gtest_main.a
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -lpthread $^ -o $(USER_DIR)/bin/$@
+
+# Serialize Unit Test
+SERIALIZE_OBJS = $(TRANSACTION_OBJS)\
+				 $(CAP_SRC)/block.o\
+				 $(CAP_SRC)/serialize.o\
+				 $(CAP_SRC)/comparator.o
+
+test_serialize_utils.o : $(TEST_UTILS)/test_serialize_utils.cpp\
+							$(TEST_UTILS)/test_serialize_utils.h
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(TEST_UTILS)/test_serialize_utils.cpp
+	
+serialize_unittest.o : $(USER_DIR)/serialize_unittest.cc\
+					$(GTEST_HEADERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -c $(USER_DIR)/serialize_unittest.cc
+
+serialize_unittest : $(SERIALIZE_OBJS) test_serialize_utils.o test_transaction_utils.o serialize_unittest.o gtest_main.a
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDES) -lpthread $^ -o $(USER_DIR)/bin/$@ 

--- a/test/serialize_unittest.cc
+++ b/test/serialize_unittest.cc
@@ -1,0 +1,37 @@
+#include "gtest/gtest.h"
+#include "serialize.h"
+#include <iostream>
+#include "test_serialize_utils.h"
+
+namespace {
+
+/*
+TEST(SerialTest,UnspentTxOut) {
+    EXPECT_TRUE(test_good_unspent_serial());
+    EXPECT_FALSE(test_bad_unspent_serial());
+}
+*/
+
+TEST(SerialTest,Transaction) {
+    EXPECT_TRUE(test_good_transaction_serial());
+    EXPECT_FALSE(test_bad_transaction_serial());
+}
+
+/*
+These will fail because the JSONtoTxIn was designed to only parse TxIn from Transactions
+TEST(SerialTest,TxIn) {
+    EXPECT_TRUE(test_good_txin_serial());
+    EXPECT_FALSE(test_bad_txin_serial());   
+}
+TEST(SerialTest,TxOut) {
+    EXPECT_TRUE(test_good_txout_serial());
+    EXPECT_FALSE(test_bad_txout_serial());
+}
+*/
+
+TEST(SerialTest,Block) {
+    EXPECT_TRUE(test_good_block_serial());
+    EXPECT_FALSE(test_bad_block_serial());
+}
+
+}

--- a/test/utils/test_serialize_utils.cpp
+++ b/test/utils/test_serialize_utils.cpp
@@ -1,0 +1,148 @@
+#include "transaction.h"
+#include "txin.h"
+#include "txout.h"
+#include "utxout.h"
+#include "serialize.h"
+
+#include <string>
+#include <iostream>
+#include <stdlib.h>
+#include <stdio.h>
+#include <time.h>
+
+#include "comparator.h"
+#include "test_serialize_utils.h"
+#include "test_transaction_utils.h"
+
+/*
+bool test_good_unspent_serial() {
+    
+    srand(time(NULL));
+    UnspentTxOut og("z","y",2,50);
+    
+    //Serialize string data
+    Serialize s(og);
+    std::string serial_data = s.toString();
+
+    //Unserialize the data
+    UnspentTxOut new_og  = JSONtoUTxO(serial_data);
+    
+    //Compare original to new_original
+    bool pass = compareUTxOut(og,new_og);
+    return pass;
+}
+
+bool test_bad_unspent_serial() {
+    Serialize s;
+
+    srand(time(NULL));
+    UnspentTxOut og("z","y",2,50);
+    UnspentTxOut fake("z","y",3,50);
+    bool pass = compareUTxOut(og,fake);
+    return pass;
+}
+*/
+bool test_good_transaction_serial() {
+    
+    srand(time(NULL));
+    TxIn in1("a", "asdasdasd", 1);
+    TxOut out1("b", 50);
+
+    TxIn in2("c", "asdfasdfasdf", 2);
+    TxOut out2("d", 100);
+
+    TxIn in3("e", "asdfadf", 3);
+    TxOut out3("f", 150);
+
+    std::vector<TxIn> ins{in1, in2, in3};
+    std::vector<TxOut> outs{out1, out2, out3};
+    Transaction og(ins, outs);
+
+    Serialize s(og);
+    std::string serial_data = s.toString();
+    /*
+    Transaction new_og = JSONtoTx(serial_data);
+
+    bool pass = compareTransaction(og,new_og);
+    return pass;
+    */
+    return false;
+}
+
+bool test_bad_transaction_serial() {
+    srand(time(NULL));
+    Transaction t1 = CreateFakeTransaction(2,4);
+    Transaction t2 = CreateFakeTransaction(1,2);
+    bool all_pass = compareTransaction(t1,t2);
+    return all_pass;
+}
+
+
+bool test_good_block_serial() {
+    //Block Genesis(0, 1521001712, 0, 0, "", GenTxns);
+    srand(time(NULL));
+    std::vector<Transaction> tlist = CreateFakeTransactionList(5);
+    Block og(0, 1521001712, 0, 0, "", tlist);
+    Serialize s(og);
+    std::string serial_data = s.toString();
+    /*
+    Block new_og = JSONtoBlock(serial_data);
+    bool pass = compareBlock(og,new_og); 
+    return pass;
+    */
+    return false;
+}
+
+bool test_bad_block_serial() {
+
+    srand(time(NULL));
+    std::vector<Transaction> tlist1 = CreateFakeTransactionList(5);
+    Block block1(0, 1521001712, 0, 0, "", tlist1);
+    std::vector<Transaction> tlist2 = CreateFakeTransactionList(5);
+    Block block2(0, 1521001712, 0, 0, "", tlist2);
+    bool pass = compareBlock(block1,block2);
+
+    return pass;
+}
+
+/*
+bool test_good_txin_serial() {
+    Serialize s;
+
+    TxIn og("a","adfsdfsd",2);
+    s(og);
+    std::string serial_data = s.toString();
+    TxIn new_og = JSONtoTxIn(serial_data);
+    bool pass = compareTxIn(og,new_og);
+    return pass;
+}
+
+bool test_bad_txin_serial() {
+    Serialize s;
+
+    TxIn t1("a", "adfsdafdsaf", 3);
+    TxIn t2("b", "fdsfsa", 5);
+    bool pass = compareTxIn(t1,t2);
+    return pass;
+}
+
+bool test_good_txout_serial() {
+    Serialize s;
+
+    TxOut og("g",123);
+    s(og);
+    std::string serial_data = s.toString();
+    TxOut new_og = JSONtoTxOut(serial_data);
+    bool pass = compareTxOut(og,new_og);
+    return pass;
+}
+
+bool test_bad_txout_serial() {
+    Serialize s;
+
+    TxOut t1("g", 123);
+    TxOut t2("gg", 421);
+    bool pass = compareTxOut(t1,t2);
+    return pass;
+}
+*/

--- a/test/utils/test_serialize_utils.h
+++ b/test/utils/test_serialize_utils.h
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <string>
+#include "transaction.h"
+#include "txin.h"
+#include "txout.h"
+#include "utxout.h"
+#include "serialize.h"
+#include <iostream>
+
+#include "comparator.h"
+
+/*
+bool test_good_unspent_serial();
+
+bool test_bad_unspent_serial();
+*/
+bool test_good_transaction_serial();
+
+bool test_bad_transaction_serial();
+
+/*
+bool test_good_txin_serial();
+
+bool test_bad_txin_serial();
+
+bool test_good_txout_serial();
+
+bool test_bad_txout_serial();
+*/
+
+bool test_good_block_serial();
+
+bool test_bad_block_serial();


### PR DESCRIPTION
Reintegrate serialize unit test:

No major changes to files.
Add comparator util functions to root source and libs.
Update make file to compile comparator
Update test make file to compile serilize unittest.

Serialize unittest and utils use the latest changes to Serialize class.

Also added getter functions to UnspentTxOut.